### PR TITLE
Lógica para gerenciamento de credenciais dos usuários autenticados

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -1,11 +1,12 @@
-import { Routes, Route, Navigate } from "react-router"
-import App from './App'
-import AgentLoginPage from "./components/auth/AgentLoginPage"
-import AgentRegisterPage from "./components/auth/AgentRegisterPage"
-import ItemListPage from "./components/items/ItemListPage"
+import { Routes, Route, Navigate } from "react-router";
+import App from './App';
+import AgentLoginPage from "./components/auth/AgentLoginPage";
+import AgentRegisterPage from "./components/auth/AgentRegisterPage";
+import ItemListPage from "./components/items/ItemListPage";
+import { useAuth } from './components/auth/AuthContext';
 
 export default function AppRoutes() {
-  const idToken = sessionStorage.getItem('idToken')
+  const { isAuthenticated } = useAuth();
 
   return (
     <Routes>
@@ -15,9 +16,9 @@ export default function AppRoutes() {
         <Route path='register' element={<AgentRegisterPage />} />
       </Route>
       <Route path='agent/item/list' element={
-        idToken ? 
-        <ItemListPage editable={true} /> : 
-        <Navigate to='/auth/login'/>
+        isAuthenticated ?
+          <ItemListPage editable={true} /> :
+          <Navigate to='/auth/login'/>
       } />
     </Routes>
   )

--- a/src/components/auth/AgentLoginPage/index.tsx
+++ b/src/components/auth/AgentLoginPage/index.tsx
@@ -10,7 +10,7 @@ export default function AgentLoginPage() {
 
   async function handleLogin(data: { email: string; password: string }) {
     try {
-      await login({ email: data.email, password: data.password })
+      await login(data.email, data.password)
       toast.success('Login realizado com sucesso!')
       navigate('/agent/item/list')
     } catch (err) {

--- a/src/components/auth/AgentRegisterPage/index.tsx
+++ b/src/components/auth/AgentRegisterPage/index.tsx
@@ -1,25 +1,13 @@
 import { toast } from "sonner"
-import { useAuth } from "../AuthContext"
-import { RegisterException } from "../AuthExceptions"
 import AgentRegisterForm from "../AgentRegisterForm"
 import { useNavigate } from "react-router"
 
 export default function AgentRegisterPage() {
-  const { register } = useAuth()
   const navigate = useNavigate()
 
-  async function handleRegister(data: { email: string, password: string }) {
-    try {
-      await register({ email: data.email, password: data.password })
-      toast.success('Registro realizado com sucesso!')
-      navigate('/auth/login')
-    } catch (err) {
-      if (err instanceof RegisterException) {
-        toast.error(err.message)
-      } else {
-        toast.error('Erro inesperado ao tentar registrar no sistema.')
-      }
-    }
+  async function handleRegister() {
+    toast.success('Registro realizado com sucesso!')
+    navigate('/auth/login')
   }
 
   return (

--- a/src/components/auth/AuthContext.tsx
+++ b/src/components/auth/AuthContext.tsx
@@ -1,75 +1,114 @@
-import { createContext, useContext, useState, type ReactNode } from 'react'
-import { LoginException, RegisterException } from './AuthExceptions'
-import type { AuthContextType, AuthData, FirebaseLoginError, FirebaseLoginSuccess, FirebaseRegisterError, FirebaseRegisterSuccess } from './AuthTypes'
+import { createContext, useState, useEffect, useContext } from 'react';
+import type { ReactNode } from 'react';
+import { useNavigate } from 'react-router';
+import AuthService from './AuthService';
+import type { UserPayload } from './AuthTypes';
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined)
+interface AuthContextType {
+  idToken: string | null;
+  refreshToken: string | null;
+  user: UserPayload | null;
+  isAuthenticated: boolean;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+  updateTokens: (idToken: string, refreshToken: string, user: UserPayload) => void;
+}
 
-const AUTH_API_URL = 'https://identitytoolkit.googleapis.com/v1/accounts:'
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+/**
+ * Provedor de contexto de autenticação.
+ * Inicializa o estado de autenticação e fornece métodos para login, logout e atualização de tokens.
+ * @param {object} props - Propriedades do componente.
+ * @param {ReactNode} props.children - Elementos filhos.
+ * @returns {JSX.Element} O provedor de contexto de autenticação.
+ */
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<AuthData | null>(null)
+  const navigate = useNavigate();
+  const [auth, setAuth] = useState<AuthContextType>({
+    idToken: null,
+    refreshToken: null,
+    user: null,
+    isAuthenticated: false,
+    loading: true,
+    login: async () => {},
+    logout: () => {},
+    updateTokens: () => {},
+  });
 
-  async function login({email, password}: AuthData) {
-    const response = await fetch(
-      `${AUTH_API_URL}signInWithPassword?key=${import.meta.env.VITE_API_KEY}`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          email: email,
-          password: password,
-          returnSecureToken: true
-        })
+  useEffect(() => {
+    /**
+     * Inicializa o estado de autenticação ao montar o componente.
+     * Recupera tokens do localStorage e define o estado de autenticação.
+     */
+    AuthService.initialize().then(result => {
+      if (result) {
+        setAuth(prev => ({ ...prev, ...result, isAuthenticated: !!result.idToken, loading: false }));
+      } else {
+        setAuth(prev => ({ ...prev, loading: false }));
       }
-    )
+    })
+  }, []);
 
-    const data: FirebaseLoginSuccess | FirebaseLoginError = await response.json()
-
-    if ('error' in data) 
-      throw new LoginException(data.error.message)
-    
-    sessionStorage.setItem('idToken', data.idToken);
-    sessionStorage.setItem('refreshToken', data.refreshToken);
+  /**
+   * Realiza o login do usuário com email e senha.
+   * Atualiza o estado de autenticação com os dados retornados do AuthService.
+   * @param {string} email - Email do usuário.
+   * @param {string} password - Senha do usuário.
+   * @returns {Promise<void>}
+   * @throws {Error} Se o login falhar.
+   */
+  const login = async (email: string, password: string) => {
+    setAuth(prev => ({ ...prev, loading: true }));
+    try {
+      const result = await AuthService.signIn(email, password);
+      setAuth(prev => ({ ...prev, ...result, isAuthenticated: !!result.idToken, loading: false }));
+    } catch (error: unknown) {
+      setAuth(prev => ({ ...prev, loading: false }));
+      throw error;
+    }
   }
 
-  async function register({email, password}: AuthData): Promise<void> {
-    const response = await fetch(
-      `${AUTH_API_URL}signUp?key=${import.meta.env.VITE_API_KEY}`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          email: email,
-          password: password,
-          returnSecureToken: true
-        })
-      }
-    )
-
-    const data: FirebaseRegisterSuccess | FirebaseRegisterError = await response.json()
-  
-    if ('error' in data) 
-      throw new RegisterException(data.error.message)
-    
-    sessionStorage.setItem('idToken', data.idToken)
-    sessionStorage.setItem('refreshToken', data.refreshToken)
+  /**
+   * Realiza o logout do usuário.
+   * Limpa os tokens do estado e do localStorage, e redireciona para a tela de login.
+   */
+  const logout = () => {
+    AuthService.logout();
+    setAuth(prev => ({
+      ...prev,
+      user: null,
+      idToken: null,
+      refreshToken: null,
+      isAuthenticated: false,
+      loading: false,
+    }));
+    navigate('/auth/login');
   }
 
-  function logout() {
-    setUser(null)
-  }
+  /**
+   * Atualiza os tokens de autenticação e o usuário no estado.
+   * @param {string} idToken - Novo idToken.
+   * @param {string} refreshToken - Novo refreshToken.
+   * @param {UserPayload} user - Novo payload do usuário.
+   */
+  const updateTokens = (idToken: string, refreshToken: string, user: UserPayload) => {
+    setAuth(prev => ({ ...prev, idToken, refreshToken, user, isAuthenticated: !!idToken }));
+  };
 
   return (
-    <AuthContext.Provider value={{ user, login, register, logout }}>
+    <AuthContext.Provider value={{ ...auth, login, logout, updateTokens }}>
       {children}
     </AuthContext.Provider>
   )
 }
 
+/**
+ * Hook para acessar o contexto de autenticação.
+ * @returns {AuthContextType} O contexto de autenticação.
+ * @throws {Error} Se usado fora do AuthProvider.
+ */
 export function useAuth() {
   const context = useContext(AuthContext)
   if (!context) throw new Error('useAuth deve ser usado dentro do AuthProvider')

--- a/src/components/auth/AuthService.ts
+++ b/src/components/auth/AuthService.ts
@@ -1,0 +1,126 @@
+import type { AuthServiceInitResult, FirebaseLoginSuccess, FirebaseLoginError, UserPayload } from './AuthTypes';
+
+class AuthService {
+  private AUTH_API_URL = 'https://identitytoolkit.googleapis.com/v1/accounts:';
+  private API_KEY = import.meta.env.VITE_API_KEY;
+
+  private LOCALSTORAGE_ID_TOKEN = 'idToken';
+  private LOCALSTORAGE_REFRESH_TOKEN = 'refreshToken';
+
+  /**
+   * Decodifica o payload de um JWT e retorna o objeto UserPayload.
+   * @param {string} token - O token JWT a ser decodificado.
+   * @returns {UserPayload | null} O payload decodificado do usuário, ou null se inválido.
+   */
+  private decodeJwtPayload(token: string): UserPayload | null {
+    try {
+      const payload = token.split('.')[1];
+      return JSON.parse(atob(payload)) as UserPayload;
+    } catch {
+      return null;
+    }
+  }
+
+
+  /**
+   * Inicializa o serviço de autenticação recuperando tokens do localStorage.
+   * Decodifica o idToken para obter o payload do usuário.
+   * @returns {Promise<AuthServiceInitResult>} Um objeto contendo idToken, refreshToken e user, ou null se não houver dados válidos.
+   */
+  async initialize(): Promise<AuthServiceInitResult> {
+    // Obter dados de autenticação da LocalStorage.
+    const idToken = localStorage.getItem(this.LOCALSTORAGE_ID_TOKEN);
+    const refreshToken = localStorage.getItem(this.LOCALSTORAGE_REFRESH_TOKEN);
+    if (!idToken || !refreshToken) return null;
+    // Obter dados do usuário.
+    const user = this.decodeJwtPayload(idToken);
+    if (!user) return null;
+    return { idToken, refreshToken, user };
+  }
+
+  /**
+   * Realiza o login do usuário utilizando email e senha.
+   * Faz uma requisição para a API do Firebase Authentication, armazena os tokens no localStorage
+   * e retorna os dados do usuário decodificados do idToken.
+   *
+   * @param {string} email - O email do usuário.
+   * @param {string} password - A senha do usuário.
+   * @returns {Promise<{ idToken: string, refreshToken: string, user: UserPayload }>} 
+   *          Um objeto contendo o idToken, refreshToken e o payload do usuário.
+   * @throws {Error} Se a autenticação falhar ou o token for inválido.
+   */
+  async signIn(email: string, password: string): Promise<{ idToken: string, refreshToken: string, user: UserPayload }> {
+    // Requisição de login.
+    const response = await fetch(
+      `${this.AUTH_API_URL}signInWithPassword?key=${this.API_KEY}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password, returnSecureToken: true })
+      }
+    );
+    const data: FirebaseLoginSuccess | FirebaseLoginError = await response.json();
+    if ('error' in data) throw new Error(data.error.message);
+    // Armezanar na LocalStorage.
+    localStorage.setItem(this.LOCALSTORAGE_ID_TOKEN, data.idToken);
+    localStorage.setItem(this.LOCALSTORAGE_REFRESH_TOKEN, data.refreshToken);
+    // Obter dados do usuário.
+    const user = this.decodeJwtPayload(data.idToken);
+    if (!user) throw new Error('Token inválido');
+    return { idToken: data.idToken, refreshToken: data.refreshToken, user };
+  }
+
+  /**
+   * Verifica se o idToken está próximo de expirar e, se necessário, faz o refresh do token.
+   * Se o token ainda for válido por mais de 2 minutos, retorna os dados atuais.
+   * Caso contrário, faz uma requisição para atualizar o token e retorna os novos dados.
+   *
+   * @param {string} idToken - O token JWT atual.
+   * @param {string} refreshToken - O refresh token atual.
+   * @returns {Promise<{ idToken: string, refreshToken: string, user: UserPayload } | null>}
+   *          Os novos tokens e payload do usuário, ou null se não for possível atualizar.
+   */
+  async refreshTokenIfNeeded(idToken: string | null, refreshToken: string | null): Promise<{ idToken: string, refreshToken: string, user: UserPayload } | null> {
+    if (!idToken || !refreshToken) return null;
+    // Obter dados de expiração do token.
+    const payload = this.decodeJwtPayload(idToken);
+    if (!payload || !payload.exp) return null;
+    const now = Math.floor(Date.now() / 1000);
+    // Se o token expira em menos de 2 minutos, faz refresh.
+    if (payload.exp - now > 120) {
+      return { idToken, refreshToken, user: payload };
+    }
+    // Faz refresh.
+    const response = await fetch(`https://securetoken.googleapis.com/v1/token?key=${this.API_KEY}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: `grant_type=refresh_token&refresh_token=${refreshToken}`
+    });
+    const data = await response.json();
+    if (!response.ok || !data.id_token) {
+      this.logout();
+      return null;
+    }
+    // Atualização na LocalStorage.
+    localStorage.setItem(this.LOCALSTORAGE_ID_TOKEN, data.id_token);
+    localStorage.setItem(this.LOCALSTORAGE_REFRESH_TOKEN, data.refresh_token);
+    // Atualizar usuário.
+    const user = this.decodeJwtPayload(data.id_token);
+    if (!user) {
+      this.logout();
+      return null;
+    }
+    return { idToken: data.id_token, refreshToken: data.refresh_token, user };
+  }
+
+  /**
+   * Remove os tokens de autenticação do localStorage, efetivamente deslogando o usuário.
+   */
+  logout() {
+    // Limpar dados na LocalStorage.
+    localStorage.removeItem(this.LOCALSTORAGE_ID_TOKEN);
+    localStorage.removeItem(this.LOCALSTORAGE_REFRESH_TOKEN);
+  }
+}
+
+export default new AuthService();

--- a/src/components/auth/AuthTypes.ts
+++ b/src/components/auth/AuthTypes.ts
@@ -3,11 +3,23 @@ export type AuthData = {
   password: string
 }
 
+export type UserPayload = {
+  user_id: string
+  email: string
+  exp: number
+  iat: number
+  [key: string]: unknown
+}
+
 export type AuthContextType = {
-  user: AuthData | null
-  login: (data: AuthData) => Promise<void>
-  register: (data: AuthData) => Promise<void>
+  idToken: string | null
+  refreshToken: string | null
+  user: UserPayload | null // payload decodificado do token
+  isAuthenticated: boolean
+  signIn: (email: string, password: string) => Promise<void>
   logout: () => void
+  updateTokens: (idToken: string, refreshToken: string, user: UserPayload) => void
+  initialized: boolean
 }
 
 export type FirebaseRegisterSuccess = {
@@ -29,3 +41,9 @@ export type FirebaseRegisterError = {
 export type FirebaseLoginSuccess = FirebaseRegisterSuccess
 
 export type FirebaseLoginError = FirebaseRegisterError
+
+export type AuthServiceInitResult = {
+  idToken: string
+  refreshToken: string
+  user: UserPayload
+} | null

--- a/src/components/items/ItemContext.tsx
+++ b/src/components/items/ItemContext.tsx
@@ -1,113 +1,156 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  useEffect,
-  type ReactNode
-} from 'react'
-import type { ItemContextType, ItemData, UploadedItem } from './ItemTypes'
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
+import { useAuth } from '../auth/AuthContext';
+import AuthService from '../auth/AuthService';
+import { toast } from 'sonner';
+import type { ItemData, UploadedItem, ItemContextType } from './ItemTypes';
 
-const ItemContext = createContext<ItemContextType | undefined>(undefined)
-
-const FIREBASE_DB_URL = import.meta.env.VITE_DATABASE_URL
+const ItemContext = createContext<ItemContextType | undefined>(undefined);
+const FIREBASE_DB_URL = import.meta.env.VITE_DATABASE_URL;
 
 export function ItemProvider({ children }: { children: ReactNode }) {
-  const [items, setItems] = useState<UploadedItem[]>([])
-
-  async function uploadItem(item: ItemData): Promise<void> {
-    const idToken = sessionStorage.getItem('idToken')
-    if (!idToken) throw new Error('Usuário não autenticado.')
-
-    const payload = {
-      ...item,
-      createdAt: new Date().toISOString()
-    }
-
-    const res = await fetch(`${FIREBASE_DB_URL}/items.json?auth=${idToken}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    })
-
-    if (!res.ok) throw new Error('Erro ao salvar item.')
-    await getItems()
-  }
-
-  async function updateItem(id: string, item: ItemData): Promise<void> {
-    const idToken = sessionStorage.getItem('idToken')
-    if (!idToken) throw new Error('Usuário não autenticado.')
-
-    const payload = {
-      ...item,
-      createdAt: new Date().toISOString()
-    }
-
-    const res = await fetch(`${FIREBASE_DB_URL}/items/${id}.json?auth=${idToken}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    })
-
-    if (!res.ok) throw new Error('Erro ao atualizar item.')
-    await getItems()
-  }
-
-  async function getItemById(id: string): Promise<UploadedItem | null> {
-    const res = await fetch(`${FIREBASE_DB_URL}/items/${id}.json`)
-    const data = await res.json()
-    return data ? { ...data } : null
-  }
-
-  async function getItems(): Promise<void> {
-    const res = await fetch(`${FIREBASE_DB_URL}/items.json`)
-    const data = await res.json()
-
-    if (!data) {
-      setItems([])
-      return
-    }
-
-    const parsed: UploadedItem[] = Object.entries(data).map(([id, item]) => ({
-      id,
-      ...(item as Omit<UploadedItem, 'id'>)
-    }))
-
-    setItems(parsed)
-  }
+  const [items, setItems] = useState<UploadedItem[]>([]);
+  const { idToken, refreshToken, updateTokens, logout } = useAuth();
 
   useEffect(() => {
-    getItems()
-  }, [])
+    getItems();
+  }, []);
 
-  const deleteItem = async (id: string): Promise<void> => {
-    const idToken = sessionStorage.getItem('idToken')
-    const response = await fetch(
-      `${FIREBASE_DB_URL}/items/${id}.json?auth=${idToken}`, 
-      {
-        method: 'DELETE',
-      }
-    )
-
+  /**
+   * Realiza uma requisição autenticada ao Firebase, atualizando o token se necessário.
+   * 
+   * @param {string} input - URL base da requisição.
+   * @param {RequestInit} [init] - Opções adicionais para a requisição fetch.
+   * @returns {Promise<Response>} - Resposta da requisição fetch.
+   * @throws {Error} - Se a sessão estiver expirada.
+   */
+  async function authFetch(input: string, init?: RequestInit): Promise<Response> {
+    // Obtem token atualziado (se necessária a atualização).
+    const refreshed = await AuthService.refreshTokenIfNeeded(idToken, refreshToken);
+    if (!refreshed) {
+      toast.error('Sessão expirada. Faça login novamente.');
+      logout();
+      throw new Error('Sessão expirada');
+    }
     
-    if (!response.ok)
-      throw new Error('Erro ao excluir item.')
-
-    setItems((prev) => prev.filter((item) => item.id !== id))
+    // Atualizar contexto de autenticação.
+    updateTokens(refreshed.idToken, refreshed.refreshToken, refreshed.user);
+    
+    // Montar requisição com o auth token.
+    const url = `${input}?auth=${refreshed.idToken}`;
+    let headers: HeadersInit | undefined = init?.headers;
+    if (init?.body) {
+      headers = {
+        ...(init?.headers || {}),
+        'Content-Type': 'application/json',
+      };
+    }
+    return fetch(url, { ...init, headers });
   }
 
+  /**
+   * Envia um novo item para o banco de dados.
+   * 
+   * @param {ItemData} item - Dados do item a ser enviado.
+   * @returns {Promise<void>}
+   * @throws {Error} - Se ocorrer erro ao salvar o item.
+   */
+  async function uploadItem(item: ItemData): Promise<void> {
+    const res = await authFetch(
+      `${FIREBASE_DB_URL}/items.json`,
+      { 
+        method: 'POST', 
+        body: JSON.stringify({ 
+          ...item, 
+          createdAt: new Date().toISOString() 
+        }) 
+      }
+    );
+    if (!res.ok) throw new Error('Erro ao salvar item. Tente novamente mais tarde.');
+    await getItems();
+  }
+
+  /**
+   * Atualiza um item existente no banco de dados.
+   * 
+   * @param {string} id - ID do item a ser atualizado.
+   * @param {ItemData} item - Novos dados do item.
+   * @returns {Promise<void>}
+   * @throws {Error} - Se ocorrer erro ao atualizar o item.
+   */
+  async function updateItem(id: string, item: ItemData): Promise<void> {
+    const res = await authFetch(
+      `${FIREBASE_DB_URL}/items/${id}.json`,
+      { 
+        method: 'PATCH', 
+        body: JSON.stringify({ 
+          ...item, 
+          createdAt: new Date().toISOString() 
+        }) 
+      }
+    );
+    if (!res.ok) throw new Error('Erro ao atualizar item. Tente novamente mais tarde.');
+    await getItems();
+  }
+
+  /**
+   * Remove um item do banco de dados.
+   * 
+   * @param {string} id - ID do item a ser removido.
+   * @returns {Promise<void>}
+   * @throws {Error} - Se ocorrer erro ao excluir o item.
+   */
+  async function deleteItem(id: string): Promise<void> {
+    const res = await authFetch(
+      `${FIREBASE_DB_URL}/items/${id}.json`,
+      { method: 'DELETE' }
+    );
+    if (!res.ok) throw new Error('Erro ao excluir item. Tente novamente mais tarde.');
+    setItems(prev => prev.filter(item => item.id !== id));
+  }
+
+  /**
+   * Busca todos os itens do banco de dados e atualiza o estado local.
+   * 
+   * @returns {Promise<void>}
+   */
+  async function getItems(): Promise<void> {
+    const res = await fetch(`${FIREBASE_DB_URL}/items.json`);
+    const data = await res.json();
+    if (!data) {
+      setItems([]);
+      return;
+    }
+    const parsed: UploadedItem[] = Object.entries(data).map(([id, item]) => ({ id, ...(item as Omit<UploadedItem, 'id'>) }));
+    setItems(parsed);
+  }
+
+  /**
+   * Busca um item pelo seu ID.
+   * 
+   * @param {string} id - ID do item a ser buscado.
+   * @returns {Promise<UploadedItem | null>} - O item encontrado ou null se não existir.
+   */
+  async function getItemById(id: string): Promise<UploadedItem | null> {
+    const res = await fetch(`${FIREBASE_DB_URL}/items/${id}.json`);
+    const data = await res.json();
+    return data ? { id, ...(data as Omit<UploadedItem, 'id'>) } : null;
+  }
 
   return (
-    <ItemContext.Provider
-      value={{ items, uploadItem, updateItem, getItemById, getItems, deleteItem }}
-    >
+    <ItemContext.Provider value={{ items, uploadItem, updateItem, getItemById, getItems, deleteItem }}>
       {children}
     </ItemContext.Provider>
-  )
-}
+  );
+};
 
+/**
+ * Hook para acessar o contexto de itens.
+ * 
+ * @returns {ItemContextType} - O contexto de itens.
+ * @throws {Error} - Se usado fora de um ItemProvider.
+ */
 export function useItems() {
-  const context = useContext(ItemContext)
-  if (!context)
-    throw new Error('useItems deve ser usado dentro de um ItemProvider')
-  return context
+  const context = useContext(ItemContext);
+  if (!context) throw new Error('useItems deve ser usado dentro de um ItemProvider');
+  return context;
 }

--- a/src/components/items/ItemListPage/index.tsx
+++ b/src/components/items/ItemListPage/index.tsx
@@ -5,6 +5,8 @@ import { toast } from "sonner"
 import { useState } from "react"
 import { useItems } from "../ItemContext"
 import ItemModal from "../ItemModal"
+import { useNavigate } from 'react-router'
+import { useAuth } from '../../auth/AuthContext'
 
 interface Props {
   editable?: boolean
@@ -14,6 +16,8 @@ export default function ItemListPage({ editable = false }: Props) {
   const { items, uploadItem, updateItem, deleteItem, getItems } = useItems()
   const [modalOpen, setModalOpen] = useState(false)
   const [editData, setEditData] = useState<UploadedItem | null>(null)
+  const navigate = useNavigate();
+  const { logout } = useAuth();
 
   function handleAdd() {
     setEditData(null)
@@ -48,7 +52,13 @@ export default function ItemListPage({ editable = false }: Props) {
     <div className="min-h-screen p-4 max-w-4xl mx-auto">
       <header className="flex justify-between items-center mb-6 border-b pb-4">
         <h1 className="text-2xl font-bold">Itens Perdidos</h1>
-        {editable && <Button onClick={handleAdd}>Adicionar Item</Button>}
+        <div className="flex items-center gap-4">
+          {editable ? 
+            <Button onClick={() => logout()}>Logout</Button> :
+            <Button onClick={() => navigate('/agent/item/list')}>Acessar portaria</Button>
+          }
+          {editable && <Button onClick={handleAdd}>Adicionar Item</Button>}
+        </div>
       </header>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,15 +13,15 @@ const root = document.getElementById('root')!
 
 createRoot(root).render(
   <StrictMode>
-    <RetrievedItemProvider>
+    <BrowserRouter>
       <AuthProvider>
-        <ItemProvider>
-          <BrowserRouter>
+        <RetrievedItemProvider>
+          <ItemProvider>
             <Toaster />
             <AppRoutes />
-          </BrowserRouter>
-        </ItemProvider>
+          </ItemProvider>
+        </RetrievedItemProvider>
       </AuthProvider>
-    </RetrievedItemProvider>
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
Foi criado um serviço de autenticação que implementa operações relacionadas ao gerenciamento de credenciais dos usuários, incluindo a lógica de login, refresh token, logout, etc. O contexto de autenticação foi refatorado para preservar e disponibilizar os dados de credenciais ao longo de toda a seção do usuário. O armazenamento local do navegador é utilizado para armazenar o `idToken` e o `refreshToken`. Informações essa que são obtidas pelo contexto de autenticação toda vez que o usuário acessa a página, preservando a autenticidade de seu último acesso, sem a necessidade de fazer login a todo momento, somente quando as credenciais expiram ou quando o mesmo faz um logout voluntário.

Foi adicionado um botão na home para que usuários autenticados possam fazer login para a página de gerenciamento de itens.

Foi adicionado um botão de logout para que usuários autenticados possam deixar o acesso a plataforma.